### PR TITLE
Update Dockerfile

### DIFF
--- a/postgis_docker-master/Dockerfile
+++ b/postgis_docker-master/Dockerfile
@@ -31,6 +31,6 @@ RUN echo "shared_preload_libraries='citus'" >> /var/lib/postgresql/data/postgres
 
 RUN apt-get install -y wget unzip
 RUN cd /home && git clone https://github.com/alitrack/duckdb_fdw
-RUN cd /home/duckdb_fdw && wget -c https://github.com/duckdb/duckdb/releases/download/v0.7.1/libduckdb-linux-amd64.zip && unzip -d . libduckdb-linux-amd64.zip && cp libduckdb.so $(/usr/lib/postgresql/15/bin/pg_config --libdir)
+RUN cd /home/duckdb_fdw && wget -c https://github.com/duckdb/duckdb/releases/download/v0.8.1/libduckdb-linux-amd64.zip && unzip -d . libduckdb-linux-amd64.zip && cp libduckdb.so $(/usr/lib/postgresql/15/bin/pg_config --libdir)
 RUN cd /home/duckdb_fdw &&  make PG_CONFIG=/usr/lib/postgresql/15/bin/pg_config USE_PGXS=1 && make PG_CONFIG=/usr/lib/postgresql/15/bin/pg_config install USE_PGXS=1
 RUN apt-get purge -y --auto-remove wget unzip


### PR DESCRIPTION
should fix 
sqlite3_api_wrapper.cpp:92:10: error: ‘unsafe_unique_array’ in namespace ‘duckdb’ does not name a template type

described in

https://github.com/alitrack/duckdb_fdw/issues/16#issuecomment-1727501599